### PR TITLE
Left-hand nav expansion issue

### DIFF
--- a/docs/latest/assets_/js/main.js
+++ b/docs/latest/assets_/js/main.js
@@ -55,6 +55,7 @@
         }
 
         function toggleNavOnClick(evt) {
+            evt.preventDefault();
             var $el = $(this);
             $el.toggleClass('opened');
             $el.next('.toc-list').stop(true, true).slideToggle(300);

--- a/docs/v0.1.0/assets_/js/main.js
+++ b/docs/v0.1.0/assets_/js/main.js
@@ -55,6 +55,7 @@
         }
 
         function toggleNavOnClick(evt) {
+            evt.preventDefault();
             var $el = $(this);
             $el.toggleClass('opened');
             $el.next('.toc-list').stop(true, true).slideToggle(300);

--- a/docs/v0.2.0/assets_/js/main.js
+++ b/docs/v0.2.0/assets_/js/main.js
@@ -55,6 +55,7 @@
         }
 
         function toggleNavOnClick(evt) {
+            evt.preventDefault();
             var $el = $(this);
             $el.toggleClass('opened');
             $el.next('.toc-list').stop(true, true).slideToggle(300);

--- a/docs/v0.3.0/assets_/js/main.js
+++ b/docs/v0.3.0/assets_/js/main.js
@@ -55,6 +55,7 @@
         }
 
         function toggleNavOnClick(evt) {
+            evt.preventDefault();
             var $el = $(this);
             $el.toggleClass('opened');
             $el.next('.toc-list').stop(true, true).slideToggle(300);

--- a/docs/v0.4.0/assets_/js/main.js
+++ b/docs/v0.4.0/assets_/js/main.js
@@ -55,6 +55,7 @@
         }
 
         function toggleNavOnClick(evt) {
+            evt.preventDefault();
             var $el = $(this);
             $el.toggleClass('opened');
             $el.next('.toc-list').stop(true, true).slideToggle(300);

--- a/docs/v0.5.0/assets_/js/main.js
+++ b/docs/v0.5.0/assets_/js/main.js
@@ -55,6 +55,7 @@
         }
 
         function toggleNavOnClick(evt) {
+            evt.preventDefault();
             var $el = $(this);
             $el.toggleClass('opened');
             $el.next('.toc-list').stop(true, true).slideToggle(300);

--- a/docs/v0.6.0/assets_/js/main.js
+++ b/docs/v0.6.0/assets_/js/main.js
@@ -55,6 +55,7 @@
         }
 
         function toggleNavOnClick(evt) {
+            evt.preventDefault();
             var $el = $(this);
             $el.toggleClass('opened');
             $el.next('.toc-list').stop(true, true).slideToggle(300);

--- a/template/assets_/js/main.js
+++ b/template/assets_/js/main.js
@@ -55,6 +55,7 @@
         }
 
         function toggleNavOnClick(evt) {
+            evt.preventDefault();
             var $el = $(this);
             $el.toggleClass('opened');
             $el.next('.toc-list').stop(true, true).slideToggle(300);


### PR DESCRIPTION
Fixes the issue in the docs left-hand navigation where clicking specifically on the `<a>` in `.toc-mod-title` causes the page to reload.
