### PR TITLE
Use localStorage to persist "Show Description" option

### DIFF
--- a/docs/latest/assets_/js/main.js
+++ b/docs/latest/assets_/js/main.js
@@ -133,19 +133,30 @@
     // ---
 
     var settings = {
+        defaultValues : {
+            'showDescription' : 'false'
+        },
 
-        init : function(key, defaultValue){
+        init : function(key){
             if (settings.get(key) == null) {
-                settings.set(key, defaultValue)
+                settings.set(key)
             }
         },
 
         get : function(key){
-            return localStorage.getItem(key);
+            var value = settings.defaultValues[key];
+            // localStorage doesn't work on IE8 w/ local files or iOS5 private browsing
+            // so we wrap into try/catch to avoid errors
+            try {
+            value = localStorage.getItem(key);
+            } catch(e){}
+            return value;
         },
 
         set : function(key, value){
+            try {
             localStorage.setItem(key, value);
+            } catch(e){}
         },
 
         toggle : function(key, alphaValue, betaValue ){

--- a/template/assets_/js/main.js
+++ b/template/assets_/js/main.js
@@ -133,25 +133,36 @@
     // ---
 
     var settings = {
+        defaultValues : {
+            'showDescription' : 'false'
+        },
 
-        init : function(key, defaultValue){
+        init : function(key){
             if (settings.get(key) == null) {
-                settings.set(key, defaultValue)
+                settings.set(key)
             }
         },
 
         get : function(key){
-            return localStorage.getItem(key);
+            var value = settings.defaultValues[key];
+            // localStorage doesn't work on IE8 w/ local files or iOS5 private browsing
+            // so we wrap into try/catch to avoid errors
+            try {
+            value = localStorage.getItem(key);
+            } catch(e){}
+            return value;
         },
 
         set : function(key, value){
+            try {
             localStorage.setItem(key, value);
+            } catch(e){}
         },
 
         toggle : function(key, alphaValue, betaValue ){
             if(settings.get(key) === alphaValue) {
                 settings.set(key, betaValue);
-                return; 
+                return;
             }
             settings.set(key, alphaValue);
         }


### PR DESCRIPTION
I've tried to follow your coding style so let me know if anything needs to change.

Basically I added two new modules:
- `description` - deals with the **Show description** checkbox and showing/hiding the descriptions
- `settings`\- abstracts away the `localStorage` API and has some convenience methods for settings. 
